### PR TITLE
Add Python2 support via pathlib2's back port of Path

### DIFF
--- a/thumbnails/conf/wrapper.py
+++ b/thumbnails/conf/wrapper.py
@@ -5,6 +5,11 @@ import os
 
 from . import defaults
 
+try:
+    from pathlib import Path
+except ImportError:
+    from pathlib2 import Path # Python 2 backport
+
 
 class SettingsWrapper(object):
 
@@ -27,8 +32,8 @@ class SettingsWrapper(object):
                 pass
 
         if not os.path.exists(self.THUMBNAIL_PATH):
-            os.makedirs(os.path.dirname(self.THUMBNAIL_PATH), exist_ok=True)
-            os.makedirs(self.THUMBNAIL_PATH, exist_ok=True)
+            Path(os.path.dirname(self.THUMBNAIL_PATH)).mkdir(exist_ok=True)
+            Path(os.path.dirname(self.THUMBNAIL_PATH)).mkdir(exist_ok=True)
 
     def __getattr__(self, key):
         value = self.defaults.get(key, 'unknown setting')

--- a/thumbnails/storage_backends.py
+++ b/thumbnails/storage_backends.py
@@ -2,10 +2,14 @@
 import codecs
 import os
 from io import BytesIO
-
 from thumbnails import helpers
 
 from .conf import settings
+
+try:
+    from pathlib import Path
+except ImportError:
+    from pathlib2 import Path # Python 2 backport
 
 
 class BaseStorageBackend(object):
@@ -51,7 +55,8 @@ class FilesystemStorageBackend(BaseStorageBackend):
     def __init__(self):
         super(FilesystemStorageBackend, self).__init__()
         if not os.path.exists(self.location):
-            os.makedirs(self.location, exist_ok=True)
+            #os.makedirs(self.location, exist_ok=True)
+            Path(self.location).mkdir(exist_ok=True)
 
     def _open(self, name, mode='rb', encoding=None, errors='strict'):
         return codecs.open(name, mode=mode, encoding=encoding, errors=errors)
@@ -60,8 +65,11 @@ class FilesystemStorageBackend(BaseStorageBackend):
         return os.path.exists(name)
 
     def _save(self, name, data):
+        print os.path.dirname(name)
+
         if not os.path.exists(os.path.dirname(name)):
-            os.makedirs(os.path.dirname(name), exist_ok=True)
+            #os.makedirs(os.path.dirname(name), exist_ok=True)
+            Path(os.path.dirname(name)).mkdir(exist_ok=True)
 
         with open(name, 'wb') as f:
             f.write(data)


### PR DESCRIPTION
Add Python2 support via pathlib2's back port of Path.

I believe this is the entirety of the changes to enable Python2 support.  (I'll double checking this later tonight...)